### PR TITLE
fix(direnv): add direnv dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 target
 
 result
+
+.direnv/


### PR DESCRIPTION
I don't have .direnv in my global .gitignore (I probably should), but since this project has an .envrc, it should ignore the direnv cache.