### PR TITLE
fix: don't error out if the before and after paths are not valid UTF-8

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -54,17 +54,12 @@ fn main() -> Result<()> {
         std::process::exit(1);
     }
 
-    let before_str = before
-        .to_str()
-        .expect("could not convert before path to str");
-    let after_str = after.to_str().expect("could not convert after path to str");
-
-    let packages: PackageListDiff = DiffRoot::new(before_str, after_str)?.into();
+    let packages: PackageListDiff = DiffRoot::new(&before, &after)?.into();
 
     let arrow_style = Style::new().bold().fg(Color::LightGray);
 
-    let before_text = format!("<<< {before_str}");
-    let after_text = format!(">>> {after_str}");
+    let before_text = format!("<<< {}", before.display());
+    let after_text = format!(">>> {}", after.display());
 
     println!("{}", arrow_style.paint(before_text));
     println!("{}\n", arrow_style.paint(after_text));

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,7 @@
 use color_eyre::Result;
-use serde::de::Deserializer;
 use serde::Deserialize;
-use std::{borrow::Cow, collections::BTreeMap, process::Command};
+use serde::de::Deserializer;
+use std::{borrow::Cow, collections::BTreeMap, path::Path, process::Command};
 
 #[derive(Deserialize, Debug)]
 pub struct DiffRoot {
@@ -41,9 +41,10 @@ where
 }
 
 impl DiffRoot {
-    pub fn new(before: &str, after: &str) -> Result<DiffRoot> {
+    pub fn new(before: &Path, after: &Path) -> Result<DiffRoot> {
         let raw_diff = Command::new("nix")
-            .args(["store", "diff-closures", "--json", before, after])
+            .args(["store", "diff-closures", "--json"])
+            .args([before, after])
             .output()?;
 
         if !raw_diff.status.success() {


### PR DESCRIPTION
Why would you have a non UTF-8 path? Idk, but this simplifies the code
and reduces the error conditions so...