### PR TITLE
feat: tilde-expand input paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +249,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,6 +296,17 @@ checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
 dependencies = [
  "indenter",
  "once_cell",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -324,6 +367,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,6 +397,7 @@ dependencies = [
  "nu-ansi-term",
  "serde",
  "serde_json",
+ "shellexpand",
  "strip-ansi-escapes",
  "terminal-light",
 ]
@@ -434,6 +487,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "owo-colors"
 version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,6 +562,23 @@ checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 
 [[package]]
 name = "rustc-demangle"
@@ -588,6 +673,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "shellexpand"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
+dependencies = [
+ "bstr",
+ "dirs",
+ "os_str_bytes",
+]
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,7 +754,7 @@ checksum = "a6f76be906d875a0ce764c52a055858c24847cb7dc674d3a5ad8cf7e3dd4ee9f"
 dependencies = [
  "coolor",
  "crossterm",
- "thiserror",
+ "thiserror 1.0.69",
  "xterm-query",
 ]
 
@@ -668,7 +764,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -676,6 +781,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -815,7 +931,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "292c33df434fde4ecd87a7afecdfa1681a3d29567fc69c774a0d83d32c095331"
 dependencies = [
  "nix",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ humansize = "2.1.3"
 nu-ansi-term = "0.50.3"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
+shellexpand = { version = "3.1.2", features = ["path"] }
 strip-ansi-escapes = "0.2.1"
 terminal-light = "1.8.0"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,7 @@ fn main() -> Result<()> {
         std::process::exit(1);
     }
 
-    let packages_diff = DiffRoot::new(lix_exe, &before, &after)?;
+    let packages_diff = DiffRoot::new(lix_exe.as_deref(), &before, &after)?;
     let mut packages: PackageListDiff = PackageListDiff::new();
     packages.by_size = args.size;
     packages.from_diff_root(packages_diff);

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use clap::Parser;
 use color_eyre::Result;
 use diff::PackageListDiff;
 use nu_ansi_term::{Color, Style};
+use shellexpand::path::tilde;
 use terminal_light::luma;
 
 mod color;
@@ -53,14 +54,14 @@ fn main() -> Result<()> {
     // Initialize color configuration
     color::init(args.no_color);
 
-    let before = args.before;
-    let after = args.after;
-    let lix_bin = args.lix_bin;
+    let before = tilde(&args.before);
+    let after = tilde(&args.after);
+    let lix_bin = args.lix_bin.as_deref().map(tilde);
 
     let mut lix_exe = None;
     if let Some(lix_bin) = lix_bin {
         lix_exe = if lix_bin.is_dir() {
-            Some(lix_bin.join("nix"))
+            Some(lix_bin.join("nix").into())
         } else {
             Some(lix_bin)
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,12 +1,7 @@
 use color_eyre::Result;
 use serde::Deserialize;
 use serde::de::Deserializer;
-use std::{
-    borrow::Cow,
-    collections::BTreeMap,
-    path::{Path, PathBuf},
-    process::Command,
-};
+use std::{borrow::Cow, collections::BTreeMap, path::Path, process::Command};
 
 #[derive(Deserialize, Debug)]
 pub struct DiffRoot {
@@ -46,12 +41,12 @@ where
 }
 
 impl DiffRoot {
-    pub fn new(lix_path: Option<PathBuf>, before: &Path, after: &Path) -> Result<DiffRoot> {
+    pub fn new(lix_path: Option<&Path>, before: &Path, after: &Path) -> Result<DiffRoot> {
         let lix_exe;
         if let Some(lix_path) = lix_path {
             lix_exe = lix_path;
         } else {
-            lix_exe = "nix".into();
+            lix_exe = Path::new("nix");
         }
 
         let raw_diff = Command::new(lix_exe)


### PR DESCRIPTION
In most situations this should already be done by the calling shell, but it is confusing to get error messages like this when it doesn't:

> After generation does not exist: ~/.local/state/nix/profiles/home-manager

No hard feelings at all if you want to just call this of scope :) Also let me know if I should drop the rustfmt commit.