### PR TITLE
fix: panic using --size without changed packages

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -75,12 +75,11 @@ impl PackageListDiff {
         };
 
         let name_width = self.longest_name + 2;
-        let package_width = (all
+        let package_width = all
             .iter()
             .map(|pkg| strip_ansi_escapes::strip(format!("{}", pkg.base_package)).len())
             .max()
-            .expect("At least one package exists"))
-        .min(120);
+            .map(|width| width.min(120));
 
         for package in &all {
             let name = &package.name;
@@ -88,6 +87,7 @@ impl PackageListDiff {
             let delta = &package.size_delta;
             let versions = format!("{package}");
             let visual_len = strip_ansi_escapes::strip(&versions).len();
+            let package_width = package_width.expect("At least one package exists");
             let padding = " ".repeat(package_width.saturating_sub(visual_len));
             writeln!(f, "{name:name_width$}{versions}{padding}  {delta}")?;
         }

--- a/src/package.rs
+++ b/src/package.rs
@@ -1,4 +1,4 @@
-use humansize::{format_size, DECIMAL};
+use humansize::{DECIMAL, format_size};
 use std::{cmp::Ordering, fmt::Display};
 
 use super::{

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,6 +1,6 @@
 use color_eyre::Result;
-use serde::de::Deserializer;
 use serde::Deserialize;
+use serde::de::Deserializer;
 use std::{
     borrow::Cow,
     collections::BTreeMap,


### PR DESCRIPTION
The previous --size code assumed that there would always be at least one
changed package between the old and new generations, and panics if there
are none.

Let me know if I should drop the rustfmt commit.